### PR TITLE
feat: 유저 선호 후보 레시피 조회 개수 16개로 수정

### DIFF
--- a/backend/app/api/routes/users/controller/request/signup_request.py
+++ b/backend/app/api/routes/users/controller/request/signup_request.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, validator
 
 MINIMUM_LOGIN_ID_LENGTH = 5
 MINIMUM_PASSWORD_LENGTH = 8
-MINIMUM_FAVOR_RECIPE_COUNT = 10
+MINIMUM_FAVOR_RECIPE_COUNT = 5
 
 class SignupRequest(BaseModel):
     login_id: str

--- a/backend/app/api/routes/users/repository/user_repository.py
+++ b/backend/app/api/routes/users/repository/user_repository.py
@@ -52,17 +52,32 @@ class FoodRepository:
 
     def find_foods(self, page_num: int, page_size: int=16) -> list:
         skip_count: int = (page_num - 1) * page_size
-        results = self.collection.find().sort([('_id', pymongo.ASCENDING)]).skip(skip_count).limit(page_size)
+        results = self.collection.find().sort([('_id', pymongo.ASCENDING)]).skip(skip_count).limit(page_size + 1)
+        # logging.debug(results)
+        results = list(results)
+        total_size = len(results)
+        logging.debug('total_size', total_size)
         lst = []
-        for result in results:
+        for i, result in enumerate(results):
+            if i == page_size: break
             result['_id'] = str(result['_id'])
+            del result['ingredients']
             lst.append(result)
-        return lst
+
+        return lst, (total_size > page_size)
     
 class RecommendationRepository:
     def __init__(self):
         self.collection = data_source.collection_with_name_as('model_recommendation_histories')
 
     def find_by_login_id(self, login_id: str) -> list:
-        result = self.collection.find_one({'login_id': login_id})
-        return result['recipe_top_20']
+        result = self.collection.find_one({'id': login_id})
+        return result['recommended_item']
+    
+class BasketRepository:
+    def __init__(self):
+        self.collection = data_source.collection_with_name_as('baskets')
+
+    def save(self, recommendation):
+        self.collection.insert_one(recommendation)
+    


### PR DESCRIPTION
## Overview
- 유저 선호 후보 레시피 조회 10개에서 16개로 수정

## Change Log
- FoodRepository find_foods 내 page_size 개수 10 -> 16으로 조정

## To Reviewer
-

## Issue Tags
- Closed: #15 
